### PR TITLE
ST-2135: Add support for segmentation file

### DIFF
--- a/tools/segmentation/segmentation.go
+++ b/tools/segmentation/segmentation.go
@@ -1,0 +1,100 @@
+package segmentation
+
+import (
+	"image"
+	"image/color"
+
+	"github.com/linkernetworks/annotation"
+	"github.com/llgcode/draw2d/draw2dimg"
+	"github.com/llgcode/draw2d/draw2dkit"
+)
+
+var fillColorPicker []color.Color
+
+func init() {
+	fillColorPicker = append(fillColorPicker, color.RGBA{0x7f, 0xff, 0x00, 0xff}) //chartreuse
+	fillColorPicker = append(fillColorPicker, color.RGBA{0x44, 0x44, 0x44, 0xff}) //chartreuse
+	fillColorPicker = append(fillColorPicker, color.RGBA{0xdc, 0x14, 0x3c, 0xff}) //crimson
+	fillColorPicker = append(fillColorPicker, color.RGBA{0xff, 0x00, 0xff, 0xff}) //fuchsia
+	fillColorPicker = append(fillColorPicker, color.RGBA{0xad, 0xff, 0x2f, 0xff}) //greenyellow
+	fillColorPicker = append(fillColorPicker, color.RGBA{0x4b, 0x00, 0x82, 0xff}) //indigo
+}
+
+type Point struct {
+	X float64
+	Y float64
+}
+
+type Object []Point
+
+type SegmentationImage struct {
+	DestImage    *image.RGBA
+	GraphContext *draw2dimg.GraphicContext
+	Objects      []Object
+}
+
+func NewSegmentationImage(img image.Image) *SegmentationImage {
+	s := new(SegmentationImage)
+	s.DestImage = image.NewRGBA(image.Rect(0, 0, img.Bounds().Dx(), img.Bounds().Dy()))
+	s.GraphContext = draw2dimg.NewGraphicContext(s.DestImage)
+
+	//Black as base image
+	s.GraphContext.SetFillColor(color.RGBA{0x00, 0x00, 0x00, 0xff})
+	draw2dkit.Rectangle(s.GraphContext, 0, 0, float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+	s.GraphContext.Fill()
+
+	s.GraphContext.SetLineWidth(5)
+	return s
+}
+
+func (s *SegmentationImage) AddPolygonAnnotation(polygon annotation.PolygonAnnotation) {
+	var obj Object
+	for i := 0; i < len(polygon.Points); {
+		pt := Point{X: float64(polygon.Points[i]), Y: float64(polygon.Points[i+1])}
+		obj = append(obj, pt)
+		i = i + 2
+	}
+	s.Objects = append(s.Objects, obj)
+}
+
+// Draw all objects with the same color.
+func (s *SegmentationImage) DrawSegmentationClassImage(file string) error {
+	s.drawObjects(s.Objects, false)
+	return draw2dimg.SaveToPngFile(file, s.DestImage)
+}
+
+// Draw all objects with the different colors.
+func (s *SegmentationImage) DrawSegmentationLabelImage(file string) error {
+	s.drawObjects(s.Objects, true)
+	return draw2dimg.SaveToPngFile(file, s.DestImage)
+}
+
+func (s *SegmentationImage) drawObjects(objs []Object, separatedObj bool) {
+	setGraphColor(s.GraphContext, 0)
+	for i, obj := range objs {
+		s.GraphContext.BeginPath() // Initialize a new path
+		for j, pt := range obj {
+			if j == 0 {
+				s.GraphContext.MoveTo(pt.X, pt.Y)
+			} else {
+				s.GraphContext.LineTo(pt.X, pt.Y)
+			}
+		}
+		//draw line to first point to close object
+		s.GraphContext.LineTo(obj[0].X, obj[0].Y)
+		s.GraphContext.Close()
+		if separatedObj {
+			if i >= len(fillColorPicker) {
+				i = (i % len(fillColorPicker))
+			}
+			setGraphColor(s.GraphContext, i)
+		}
+		s.GraphContext.FillStroke()
+	}
+}
+
+// set color with color preset table
+func setGraphColor(gc *draw2dimg.GraphicContext, index int) {
+	gc.SetStrokeColor(fillColorPicker[index])
+	gc.SetFillColor(fillColorPicker[index])
+}

--- a/tools/segmentation/segmentation_test.go
+++ b/tools/segmentation/segmentation_test.go
@@ -1,0 +1,76 @@
+package segmentation
+
+import (
+	"image"
+	_ "image/jpeg"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/linkernetworks/annotation"
+)
+
+const sourceFile string = "../../test_img/Aaron_Eckhart_0001.jpg"
+const targetLabelFile string = "./obj.jpg"
+const targetClassFile string = "./class.jpg"
+
+func prepareTestPolygon() []annotation.PolygonAnnotation {
+	return []annotation.PolygonAnnotation{
+		annotation.PolygonAnnotation{
+			Label:  "aaa",
+			Points: []annotation.Point{50, 50, 100, 50, 100, 100},
+		},
+		annotation.PolygonAnnotation{
+			Label:  "bbb",
+			Points: []annotation.Point{150, 50, 110, 50, 110, 100},
+		},
+	}
+}
+func TestSegementationLabel(t *testing.T) {
+	reader, err := os.Open(sourceFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer reader.Close()
+
+	m, _, err := image.Decode(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	anns := prepareTestPolygon()
+
+	seg := NewSegmentationImage(m)
+	for _, ann := range anns {
+		seg.AddPolygonAnnotation(ann)
+	}
+	if err := seg.DrawSegmentationLabelImage(targetLabelFile); err != nil {
+		t.Fatal(err)
+	}
+	os.Remove(targetLabelFile)
+}
+
+func TestSegementationObj(t *testing.T) {
+	reader, err := os.Open(sourceFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer reader.Close()
+
+	m, _, err := image.Decode(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	anns := prepareTestPolygon()
+
+	seg := NewSegmentationImage(m)
+	for _, ann := range anns {
+		seg.AddPolygonAnnotation(ann)
+	}
+	if err := seg.DrawSegmentationClassImage(targetClassFile); err != nil {
+		t.Fatal(err)
+	}
+
+	os.Remove(targetClassFile)
+}


### PR DESCRIPTION
**Request:**

Quote from the VOC document:

```
For the segmentation taster task, corresponding image sets are provided as in
the classification/detection tasks. These image sets are subsets of those for the
main tasks, for which pixel-wise segmentations have been prepared. Table 2
summarizes the number of objects and images (containing at least one object
of a given class) for each class and image set. In addition to the segmented
images for training and validation, participants are free to use the un-segmented
training/validation images supplied for the main classification/detection tasks.

```
In order to generate the segmentation file, the go program needs to draw the polygon on a two-channels image.

See draw2d for more details

https://github.com/llgcode/draw2d/blob/master/README.md
