### PR TITLE
Feature: Support Labelme color

### DIFF
--- a/tools/labelme/labelme.go
+++ b/tools/labelme/labelme.go
@@ -27,7 +27,21 @@ type Shape struct {
 type Point [2]int
 
 func (l *LabelmeJSON) AddShape(s Shape) {
-	l.Shapes = append(l.Shapes, s)
+	// Labelme spec not allow point or line (two points) input shape.
+	// We will skip it.
+	if len(s.Points) > 2 {
+		if s.FillColor != nil {
+			l.FillColor = *s.FillColor
+			s.FillColor = nil
+		}
+
+		if s.LineColor != nil {
+			l.LineColor = *s.LineColor
+			s.LineColor = nil
+		}
+		l.Shapes = append(l.Shapes, s)
+	}
+
 }
 
 func (l *LabelmeJSON) JSON() ([]byte, error) {

--- a/tools/labelme/labelme.go
+++ b/tools/labelme/labelme.go
@@ -1,7 +1,10 @@
 package labelme
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"log"
 
 	"github.com/linkernetworks/annotation"
 )
@@ -31,6 +34,12 @@ func (l *LabelmeJSON) JSON() ([]byte, error) {
 	return json.MarshalIndent(l, "  ", " ")
 }
 
+func PolygonAnnotationToShapeWithColorString(ann annotation.PolygonAnnotation, lineColor string, fillColor string) Shape {
+	line := colorStringToIntArray(lineColor)
+	fill := colorStringToIntArray(fillColor)
+	return PolygonAnnotationToShape(ann, &line, &fill)
+}
+
 func PolygonAnnotationToShape(ann annotation.PolygonAnnotation, lineColor *[4]int, fillColor *[4]int) Shape {
 	s := Shape{
 		Label:     ann.Label,
@@ -44,6 +53,12 @@ func PolygonAnnotationToShape(ann annotation.PolygonAnnotation, lineColor *[4]in
 	return s
 }
 
+func RectAnnotationToShapeWithColorString(ann annotation.RectAnnotation, lineColor string, fillColor string) Shape {
+	line := colorStringToIntArray(lineColor)
+	fill := colorStringToIntArray(fillColor)
+	return RectAnnotationToShape(ann, &line, &fill)
+}
+
 func RectAnnotationToShape(ann annotation.RectAnnotation, lineColor *[4]int, fillColor *[4]int) Shape {
 	s := Shape{
 		Label:     ann.Label,
@@ -55,4 +70,19 @@ func RectAnnotationToShape(ann annotation.RectAnnotation, lineColor *[4]int, fil
 	s.Points = append(s.Points, [2]int{ann.X + ann.Width, ann.Y + ann.Height})
 	s.Points = append(s.Points, [2]int{ann.X, ann.Y + ann.Height})
 	return s
+}
+
+func colorStringToIntArray(s string) [4]int {
+	var ret [4]int
+	data, err := hex.DecodeString(s[1:])
+	if err != nil {
+		log.Printf("colorStringToIntArray: %v\n", err)
+		return ret
+	}
+	for k, v := range data {
+		fmt.Printf("% d\n", v)
+		ret[k] = int(v)
+	}
+
+	return ret
 }

--- a/tools/labelme/labelme_test.go
+++ b/tools/labelme/labelme_test.go
@@ -219,3 +219,25 @@ func TestLabelMeRectNagtiveHeight(t *testing.T) {
 	t.Log(string(ret))
 	assert.Equal(t, compareString, ret)
 }
+
+func TestColorToInt(t *testing.T) {
+	// "#D0021B" only RGB
+	expect := [4]int{208, 2, 27, 0}
+	ans := colorStringToIntArray("#D0021B")
+	assert.Equal(t, expect, ans)
+
+	// "#D0021B0A" include RGBA
+	expect = [4]int{208, 2, 27, 10}
+	ans = colorStringToIntArray("#D0021B0A")
+	assert.Equal(t, expect, ans)
+
+	// low case: RGBA lower case
+	expect = [4]int{208, 2, 27, 10}
+	ans = colorStringToIntArray("#d0021b0a")
+	assert.Equal(t, expect, ans)
+
+	// odd-digit hexadecimal will return empty
+	expect = [4]int{0, 0, 0, 0}
+	ans = colorStringToIntArray("#d0021ba")
+	assert.Equal(t, expect, ans)
+}


### PR DESCRIPTION
**Problem:**

- Labelme annotation not include color from FE
- Labelme don't accept point and line (two points) shape

**Solution:**

- Support color
- Add shape constraint

**Side Effect:**

- None
